### PR TITLE
[RFR] Fix gem for Rails 5

### DIFF
--- a/lib/time_for_a_boolean.rb
+++ b/lib/time_for_a_boolean.rb
@@ -1,7 +1,7 @@
 require "active_support/core_ext/module/delegation"
-require "active_record/connection_adapters/column"
 require "time_for_a_boolean/version"
 require "time_for_a_boolean/railtie"
+require "time_for_a_boolean/constants"
 
 module TimeForABoolean
   def time_for_a_boolean(attribute, field="#{attribute}_at")
@@ -13,7 +13,7 @@ module TimeForABoolean
 
     setter_attribute = "#{field}="
     define_method("#{attribute}=") do |value|
-      if ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.include?(value)
+      if Constants::TRUE_VALUES.include?(value)
         send(setter_attribute, -> { Time.current }.())
       else
         send(setter_attribute, nil)

--- a/lib/time_for_a_boolean/constants.rb
+++ b/lib/time_for_a_boolean/constants.rb
@@ -1,0 +1,5 @@
+module TimeForABoolean
+  module Constants
+    TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE', 'on', 'ON'].to_set
+  end
+end

--- a/spec/time_for_a_boolean_spec.rb
+++ b/spec/time_for_a_boolean_spec.rb
@@ -24,6 +24,9 @@ describe TimeForABoolean do
   end
 
   describe 'attribute method' do
+    let(:past_time) { Time.now - 10 }
+    let(:future_time) { Time.now + 86400 }
+
     it 'calls nil? on the backing timestamp' do
       klass.time_for_a_boolean :attribute
       timestamp = double(nil?: true)
@@ -36,7 +39,7 @@ describe TimeForABoolean do
 
     it 'is true if the attribute is not nil' do
       klass.time_for_a_boolean :attribute
-      allow(object).to receive(:attribute_at).and_return(Time.now - 10)
+      allow(object).to receive(:attribute_at).and_return(past_time)
 
       expect(object.attribute).to be_truthy
     end
@@ -50,12 +53,15 @@ describe TimeForABoolean do
 
     it 'is false if the attribute time is in the future' do
       klass.time_for_a_boolean :attribute
-      allow(object).to receive(:attribute_at).and_return(Time.now + 86400) # one day in the future
+      allow(object).to receive(:attribute_at).and_return(future_time) # one day in the future
 
       expect(object.attribute).to be_falsey
     end
 
     context 'when the user has defined their own attribute name' do
+      let(:future_date) { Date.current + 2 }
+      let(:past_date) { Date.current - 10 }
+
       it 'calls nil? on the backing value' do
         klass.time_for_a_boolean :attribute, :attribute_on
         date = double(nil?: true)
@@ -68,7 +74,7 @@ describe TimeForABoolean do
 
       it 'is true if the attribute is not nil' do
         klass.time_for_a_boolean :attribute, :attribute_on
-        allow(object).to receive(:attribute_on).and_return(Date.current - 10)
+        allow(object).to receive(:attribute_on).and_return(past_date)
 
         expect(object.attribute).to be_truthy
       end
@@ -82,7 +88,7 @@ describe TimeForABoolean do
 
       it 'is false if the attribute date is in the future' do
         klass.time_for_a_boolean :attribute, :attribute_on
-        allow(object).to receive(:attribute_on).and_return(Time.current + 1)
+        allow(object).to receive(:attribute_on).and_return(future_date)
 
         expect(object.attribute).to be_falsey
       end

--- a/spec/time_for_a_boolean_spec.rb
+++ b/spec/time_for_a_boolean_spec.rb
@@ -2,6 +2,7 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'time_for_a_boolean'
+require 'active_support/core_ext/time/calculations'
 
 describe TimeForABoolean do
   it 'defines the attribute method' do
@@ -81,7 +82,7 @@ describe TimeForABoolean do
 
       it 'is false if the attribute date is in the future' do
         klass.time_for_a_boolean :attribute, :attribute_on
-        allow(object).to receive(:attribute_on).and_return(Date.current + 1)
+        allow(object).to receive(:attribute_on).and_return(Time.current + 1)
 
         expect(object.attribute).to be_falsey
       end


### PR DESCRIPTION
Previously, this gem was depending on the constant `ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES` from Rails for setting the `attribute=` value-- the logic is a `true` value sets the `attribute_at` column to `Time.current`, and any other value sets the column to `nil`. The gem broke when that constant was removed from Rails.

https://github.com/rails/rails/commit/a502703c3d2151d4d3b421b29fefdac5ad05df61

This PR adds a constant containing the same values to the gem.
